### PR TITLE
Fix crypt_types() subroutine name

### DIFF
--- a/lib/Crypt/Passphrase/PBKDF2.pm
+++ b/lib/Crypt/Passphrase/PBKDF2.pm
@@ -59,7 +59,7 @@ sub needs_rehash {
 	return;
 }
 
-sub crypt_types {
+sub crypt_subtypes {
 	return map { "pbkdf2-$_" } keys %param_for_type;
 }
 


### PR DESCRIPTION
I don't see a `crypt_types()` sub referenced elsehwhere in the Crypt::Passphrase corpus. As is, the password verification for PBKDF2 hashes fails. Changing the sub name to `crypt_subtypes()` fixes it.